### PR TITLE
Enhancement: mandatory colon restriction for keyword removed

### DIFF
--- a/src/editor-extension/editor-highlighter.ts
+++ b/src/editor-extension/editor-highlighter.ts
@@ -47,7 +47,7 @@ export class EditorHighlighter implements PluginValue {
     keyword: KeywordStyle
   ): NewDecoration[] {
     const newDecorations: NewDecoration[] = [];
-    const cursor = new SearchCursor(view.state.doc, `${keyword.keyword}:`);
+    const cursor = new SearchCursor(view.state.doc, `${keyword.keyword}`);
     cursor.next();
     while (!cursor.done) {
       newDecorations.push({

--- a/src/reader-extension/reader-highlighter.ts
+++ b/src/reader-extension/reader-highlighter.ts
@@ -16,7 +16,7 @@ function replaceWithHighlight(node: Node, keyword: KeywordStyle) {
   ) {
     return;
   } else if (node.nodeType === Node.TEXT_NODE && node.nodeValue) {
-    const searchText = `${keyword.keyword}:`;
+    const searchText = `${keyword.keyword}`;
     const index = node.nodeValue.indexOf(searchText);
     if (index > -1) {
       // parent cannot be null


### PR DESCRIPTION
Hi, just started using the plugin. I find it awesome, but I don't think that mandatory colon symbol enforcement is a good idea.
In some cases keyword is just a word that needs to be highlighted. Currently it's impossible to enable highlight without having ":" in text after the keyword.

With these changes, a user still can add the colon symbol in keyword definition if so desires. For example, previously defined keyword `TODO` can be defined now as `TODO:` if needed.

I believe this provides user with more control on keyword format definition.

Seems related to #5 